### PR TITLE
feat: extend theme tokens for cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -18,11 +18,19 @@
   --foreground-subtle: #9ca3af;
   
   --accent: #2563eb;
+  --accent-secondary: #7c3aed;
   --accent-soft: #dbeafe;
   --accent-hover: #1d4ed8;
+  --accent-glow: rgba(37, 99, 235, 0.35);
   --button-primary-text: #ffffff;
   --neutral-soft: #edf2f7;
   --focus-ring: rgba(37, 99, 235, 0.28);
+
+  /* Card treatments */
+  --card-base-shadow: var(--shadow-sm);
+  --card-elevated-shadow: var(--shadow-md);
+  --card-hover-shadow: var(--shadow-lg);
+  --card-hover-border: rgba(37, 99, 235, 0.2);
   
   --success: #16a34a;
   --success-soft: #dcfce7;
@@ -70,11 +78,18 @@
   --foreground-subtle: #94a3b8;
   
   --accent: #60a5fa;
+  --accent-secondary: #a855f7;
   --accent-soft: rgba(96, 165, 250, 0.15);
   --accent-hover: #3b82f6;
+  --accent-glow: rgba(96, 165, 250, 0.4);
   --button-primary-text: #0f172a;
   --neutral-soft: rgba(148, 163, 184, 0.16);
   --focus-ring: rgba(96, 165, 250, 0.35);
+
+  --card-base-shadow: var(--shadow-sm);
+  --card-elevated-shadow: var(--shadow-md);
+  --card-hover-shadow: var(--shadow-lg);
+  --card-hover-border: rgba(96, 165, 250, 0.3);
 }
 
 /* Base styles */


### PR DESCRIPTION
## Summary
- add secondary accent and glow tokens to the global theme palette for gradients and emphasis states
- introduce card shadow and border tokens that reuse the existing shadow scale for consistent elevations
- mirror the new design tokens in the dark theme override to maintain parity

## Testing
- npm run lint *(fails: existing xo configuration reports widespread lint errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68cd98b87230832e9cd61ff16c307ec9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded theming with new tokens for accents and card appearance, delivering more consistent styling across light and dark themes.
  - Improved visual depth with enhanced elevation, hover states, and borders for cards.

- Style
  - Refined accent treatments for a more cohesive look.
  - Polished card visuals, including shadows and hover feedback, for a clearer sense of interaction and hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->