### PR TITLE
Use theme variables for card styles

### DIFF
--- a/app/components/ui/card.tsx
+++ b/app/components/ui/card.tsx
@@ -5,13 +5,13 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/app/lib/utils";
 
 const cardVariants = cva(
-  "rounded-xl border bg-white shadow-lg gpu-accelerated card-hover",
+  "rounded-xl border border-[var(--surface-border)] bg-[var(--surface)] shadow-lg gpu-accelerated card-hover",
   {
     variants: {
       variant: {
-        default: "border-[#E6EEF5]",
+        default: "border-[var(--surface-border)]",
         elevated: "panel-elevated",
-        outlined: "border-2 border-[#A4CBE1]",
+        outlined: "border-2 border-[var(--surface-border)]",
         ghost: "border-transparent shadow-none",
       },
       padding: {
@@ -61,7 +61,10 @@ const CardTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("font-semibold leading-none tracking-tight font-heading text-[#00263E]", className)}
+    className={cn(
+      "font-semibold leading-none tracking-tight font-heading text-[var(--foreground)]",
+      className,
+    )}
     {...props}
   />
 ));
@@ -73,7 +76,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-sm text-gray-600 font-body", className)}
+    className={cn("text-sm text-[var(--foreground-muted)] font-body", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## Summary
- use the shared surface and border variables for the card container styles
- align card title and description typography with foreground theme tokens so text adapts to dark mode

## Testing
- npm run test
- npm run lint *(fails: repository has thousands of existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd98c0d528832e94e7f5e99bcb43c0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated Card component styling to use theme variables for borders and backgrounds, improving consistency across light/dark themes.
  - Standardized border appearance across default and outlined variants for a more cohesive look.
  - Refreshed CardTitle and CardDescription colors to enhance readability and align with system foreground tones.
  - Minor class consolidation for cleaner presentation without altering component behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->